### PR TITLE
swap hash ldscript comment for higher build compat

### DIFF
--- a/message.sym
+++ b/message.sym
@@ -10,7 +10,7 @@ _MSG_18 = 0x18;
 _MSG_19 = 0x19;
 _MSG_1a = 0x1a;
 
-# shiftable __MessageID IDs (named by value; pending semantic names)
+/* shiftable __MessageID IDs (named by value; pending semantic names) */
 _MSG_e30 = 0xe30;
 _MSG_e70 = 0xe70;
 _MSG_eb0 = 0xeb0;


### PR DESCRIPTION
Building currently fails when using

```sh
ld --version
GNU ld (GNU Binutils for Ubuntu) 2.44
Copyright (C) 2025 Free Software Foundation, Inc.
This program is free software; you may redistribute it under the terms of
the GNU General Public License version 3 or (at your option) a later version.
This program has absolutely no warranty.
```

By swapping the `#` comment for `/* ... */`, then I am able to build with this version according to the project instructions.

Credits to [SBird1337](https://github.com/SBird1337) for suggesting the fix.

-Lan